### PR TITLE
Updates to work with Python3

### DIFF
--- a/fixity/fixity.py
+++ b/fixity/fixity.py
@@ -11,7 +11,6 @@ import traceback
 from models import Report, Session
 import reporting
 import storage_service
-from utils import InvalidUUID
 
 
 class ArgumentError(Exception):

--- a/fixity/reporting.py
+++ b/fixity/reporting.py
@@ -1,7 +1,7 @@
 import calendar
 import json
 
-from utils import check_valid_uuid
+from .utils import check_valid_uuid
 
 import requests
 

--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -5,8 +5,8 @@ import json
 import requests
 from sqlalchemy.orm.exc import NoResultFound
 
-from models import AIP, Report
-from utils import check_valid_uuid
+from .models import AIP, Report
+from .utils import check_valid_uuid
 
 
 UNABLE_TO_CONNECT_ERROR = "Unable to connect to storage service instance at {} (is it running?)"

--- a/fixity/utils.py
+++ b/fixity/utils.py
@@ -1,5 +1,11 @@
 from uuid import UUID
 
+try:
+    # Python2
+    STRING_TYPES = basestring
+except NameError:
+    # Python3
+    STRING_TYPES = str
 
 class InvalidUUID(Exception):
     def __init__(self, uuid):
@@ -18,7 +24,7 @@ def check_valid_uuid(uuid):
     This uses the UUID() class constructor from the uuid module,
     which raises a ValueError if the passed string is not a valid UUID.
     """
-    if not isinstance(uuid, basestring):
+    if not isinstance(uuid, STRING_TYPES):
         raise TypeError("UUID must be a string")
 
     try:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,3 +1,4 @@
+-r base.txt
 ipython==2.0.0
-pytest==2.5.2
+pytest==2.8.7
 vcrpy==1.0.0

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -27,7 +27,7 @@ def test_single_aip_raises_on_404():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.get_single_aip('ba31d9b8-5baa-4d62-839e-cf71497d4acf', STORAGE_SERVICE_URL)
 
-    assert "returned 404" in ex.value.message
+    assert "returned 404" in str(ex.value)
     assert ex.value.report is None
 
 
@@ -36,7 +36,7 @@ def test_single_aip_raises_on_500():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.get_single_aip('a7f2a05b-0fdf-42f1-a46c-4522a831cf17', STORAGE_SERVICE_URL)
 
-    assert "internal error" in ex.value.message
+    assert "internal error" in str(ex.value)
     assert ex.value.report is None
 
 
@@ -45,7 +45,7 @@ def test_single_aip_raises_on_504():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.get_single_aip('a7f2a05b-0fdf-42f1-a46c-4522a831cf17', STORAGE_SERVICE_URL)
 
-    assert "gateway timeout" in ex.value.message
+    assert "gateway timeout" in str(ex.value)
     assert ex.value.report is None
 
 
@@ -58,7 +58,7 @@ def test_single_aip_raises_with_invalid_url():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.get_single_aip('a7f2a05b-0fdf-42f1-a46c-4522a831cf17', "http://foo")
 
-    assert "Unable to connect" in ex.value.message
+    assert "Unable to connect" in str(ex.value)
 
 
 ### All AIPs
@@ -77,7 +77,7 @@ def test_get_all_aips():
 @vcr.use_cassette('fixtures/vcr_cassettes/all_aips_uploaded_only.yaml')
 def test_get_all_aips_gets_uploaded_aips_only():
     aips = storage_service.get_all_aips(STORAGE_SERVICE_URL)
-    non_uploaded = filter(lambda a: a['status'] != u"UPLOADED", aips)
+    non_uploaded = list(filter(lambda a: a['status'] != u"UPLOADED", aips))
     assert len(non_uploaded) == 0
 
 
@@ -86,7 +86,7 @@ def test_get_all_aips_raises_on_500():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.get_all_aips(STORAGE_SERVICE_URL)
 
-    assert "internal error" in ex.value.message
+    assert "internal error" in str(ex.value)
     assert ex.value.report is None
 
 
@@ -95,7 +95,7 @@ def test_get_all_aips_raises_on_504():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.get_all_aips(STORAGE_SERVICE_URL)
 
-    assert "gateway timeout" in ex.value.message
+    assert "gateway timeout" in str(ex.value)
     assert ex.value.report is None
 
 
@@ -103,7 +103,7 @@ def test_get_all_aips_raises_with_invalid_url():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.get_all_aips("http://foo")
 
-    assert "Unable to connect" in ex.value.message
+    assert "Unable to connect" in str(ex.value)
 
 
 ### Fixity scan
@@ -138,7 +138,7 @@ def test_fixity_scan_raises_on_500():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.scan_aip('a7f2a05b-0fdf-42f1-a46c-4522a831cf17', STORAGE_SERVICE_URL, SESSION)
 
-    assert "internal error" in ex.value.message
+    assert "internal error" in str(ex.value)
 
 
 @vcr.use_cassette('fixtures/vcr_cassettes/fixity_non_200.yaml')
@@ -146,11 +146,11 @@ def test_fixity_scan_raises_on_non_200():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.scan_aip('a7f2a05b-0fdf-42f1-a46c-4522a831cf17', STORAGE_SERVICE_URL, SESSION)
 
-    assert "returned 504" in ex.value.message
+    assert "returned 504" in str(ex.value)
 
 
 def test_fixity_scan_raises_on_invalid_url():
     with pytest.raises(storage_service.StorageServiceError) as ex:
         storage_service.scan_aip('a7f2a05b-0fdf-42f1-a46c-4522a831cf17', "http://foo", SESSION)
 
-    assert "Unable to connect" in ex.value.message
+    assert "Unable to connect" in str(ex.value)


### PR DESCRIPTION
- Use relative imports
- <s>Use `six` for checking string types</s> Replicated functionality inside fixity.
- Update pytest version past python3 bug
- Python3 exceptions don't have a `message`, so check against the string repr
- Convert filter iterable to a list
