### PR TITLE
Arkivum integration updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Usage
 
 For more information on usage, consult the [manpage](docs/fixity.1.md).
 
-
-
 Copyright
 ---------
 

--- a/docs/fixity.1
+++ b/docs/fixity.1
@@ -25,6 +25,10 @@ fixity requires several environment variables to be exported when it is running;
 Time (in seconds) to wait when scanning multiple AIPs\. This can help reduce extended disk load on the filesystem on which the AIPs reside\.
 .
 .TP
+\fB\-\-force\-local\fR
+Request the Storage Service performs a local fixity check, instead of using the Space\'s fixity (if available)\.
+.
+.TP
 \fB\-\-debug\fR
 Print extra debugging output\.
 .

--- a/docs/fixity.1.html
+++ b/docs/fixity.1.html
@@ -88,6 +88,7 @@
 
 <dl>
 <dt><code>--throttle</code> <var>seconds</var></dt><dd><p>Time (in seconds) to wait when scanning multiple AIPs. This can help reduce extended disk load on the filesystem on which the AIPs reside.</p></dd>
+<dt><code>--force-local</code></dt><dd><p>Request the Storage Service performs a local fixity check, instead of using the Space's fixity (if available).</p></dd>
 <dt class="flush"><code>--debug</code></dt><dd><p>Print extra debugging output.</p></dd>
 </dl>
 

--- a/docs/fixity.1.md
+++ b/docs/fixity.1.md
@@ -18,6 +18,9 @@ fixity requires several environment variables to be exported when it is running;
   * `--throttle` <seconds>:
     Time (in seconds) to wait when scanning multiple AIPs. This can help reduce extended disk load on the filesystem on which the AIPs reside.
 
+  * `--force-local`:
+    Request the Storage Service performs a local fixity check, instead of using the Space's fixity (if available).
+
   * `--debug`:
     Print extra debugging output.
 

--- a/fixity/fixity.py
+++ b/fixity/fixity.py
@@ -66,7 +66,14 @@ def fetch_environment_variables(namespace):
 
 
 def scan_message(aip_uuid, status, message):
-    succeeded = "succeeded" if status else "failed"
+    if status is True:
+        succeeded = 'succeeded'
+    elif status is False:
+        succeeded = 'failed'
+    elif status is None:
+        succeeded = "didn't run"
+    else:
+        succeeded = 'returned an unknown status'
     output = "Fixity scan {} for AIP: {}".format(succeeded, aip_uuid)
     if message:
         output += ' ({})'.format(message)

--- a/fixity/reporting.py
+++ b/fixity/reporting.py
@@ -71,6 +71,8 @@ def post_success_report(aip, report, report_url, report_auth=(), session_id=None
     This is an optional parameter, but some reporting services will require it.
     (For instance, the DRMC requires this to be POSTed with every report.)
     """
+    if report and report.success is None:
+        return None
     check_valid_uuid(aip)
 
     body = report.report

--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -105,7 +105,7 @@ def create_report(aip, success, begun, ended, report_string):
     )
 
 
-def scan_aip(aip_uuid, ss_url, ss_user, ss_key, session, start_time=None):
+def scan_aip(aip_uuid, ss_url, ss_user, ss_key, session, start_time=None, force_local=False):
     """
     Scans fixity for the given AIP.
 
@@ -124,6 +124,9 @@ def scan_aip(aip_uuid, ss_url, ss_user, ss_key, session, start_time=None):
     be calculated immediately before the scan begins. This should be
     passed in the case that a pre-scan report will be POSTed to a server,
     in which case both reports should have the identical time.
+
+    force_local, if True, will request the Storage Service to perform a local
+    fixity check, instead of using the Space's fixity (if available).
 
     A tuple of (success, report) is returned.
 
@@ -151,6 +154,8 @@ def scan_aip(aip_uuid, ss_url, ss_user, ss_key, session, start_time=None):
         begun = start_time
 
     params = {'username': ss_user, 'api_key': ss_key}
+    if force_local:
+        params = {'username': ss_user, 'api_key': ss_key, 'force_local': force_local}
     try:
         response = requests.get(ss_url + 'api/v2/file/' + aip.uuid + '/check_fixity/', params=params)
     except requests.ConnectionError:

--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -212,8 +212,14 @@ def scan_aip(aip_uuid, ss_url, ss_user, ss_key, session, start_time=None):
         )
 
     report = response.json()
-    report["started"] = begun_int
-    report["finished"] = ended_int
+    if report.get('timestamp'):
+        timestamp = datetime.strptime(report['timestamp'], "%Y-%m-%dT%H:%M:%S")
+        timestamp = int(calendar.timegm(timestamp.utctimetuple()))
+        report["started"] = timestamp
+        report["finished"] = timestamp
+    else:
+        report["started"] = begun_int
+        report["finished"] = ended_int
     if "success" not in report:
         report["success"] = None
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="fixity",
-    version="0.2",
+    version="0.3",
     packages=["fixity"],
     url = 'https://github.com/artefactual/fixity',
     author = 'Artefactual Systems',

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -148,3 +148,18 @@ def test_posting_success_report_posted_is_false_on_raise():
         pass
 
     assert report.posted is False
+
+def test_posting_success_report_success_none():
+    json_report = json_string("test_failed_report.json")
+    aip = AIP(
+        uuid="ed42aadc-d854-46c6-b455-cd384eef1618"
+    )
+    report = Report(
+        aip=aip,
+        begun=datetime.fromtimestamp(1400022946),
+        ended=datetime.fromtimestamp(1400023208),
+        success=None,
+        posted=False,
+        report=json_report
+    )
+    assert reporting.post_success_report(aip.uuid, report, REPORT_URL) is None


### PR DESCRIPTION
- Save began and end times to the report
- Use the storage-service provided timestamp if available
- If scan success was None (because of an error unrelated to the fixity's success/failure), suppress POSTing a report afterwards
