### PR TITLE
Dev/issue 10981 scanall error

### DIFF
--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -26,11 +26,15 @@ class StorageServiceError(Exception):
         super(StorageServiceError, self).__init__(message)
 
 
-def _get_aips(ss_url, ss_user, ss_key, uri='api/v2/file/'):
-    url = ss_url + uri
-    params = {'username': ss_user, 'api_key': ss_key}
+def _get_aips(ss_url, ss_user, ss_key, uri=None):
     try:
-        response = requests.get(url, params=params)
+        if uri:
+            url = ss_url + uri
+            response = requests.get(url)
+        else:
+            url = ss_url + 'api/v2/file/'
+            params = {'username': ss_user, 'api_key': ss_key}
+            response = requests.get(url, params=params)
     except requests.ConnectionError:
         raise StorageServiceError(UNABLE_TO_CONNECT_ERROR.format(ss_url))
 


### PR DESCRIPTION
Previously, ``_get_aips`` was concatenating the server-supplied URL path for the next batch of AIPs (held in the ``uri`` param) to the SS URL. However, since the server-supplied URL path already contained GET params for api_key, username, offset, etc. the default behaviour was duplicating those params and generating a request URL that, after enough iterations, would result in a "Request Line is too large" error (from Gunicorn, I believe). In order to notice this error, you would need to be running fixity on hundreds of AIPs.