### PR TITLE
Re-enable writing reports to the Fixity database

### DIFF
--- a/fixity/fixity.py
+++ b/fixity/fixity.py
@@ -156,6 +156,9 @@ def scan(aip, ss_url, ss_user, ss_key, session, report_url=None, report_auth=(),
             print("Unable to POST report for AIP {} to remote service".format(aip),
                   file=sys.stderr)
 
+    if report:
+        session.add(report)
+
     return status
 
 


### PR DESCRIPTION
This commit adds a line back into the code that seemed to have been removed in 2014. As it stands, there isn't another place in the tool where the Report object is written to the database and so the only output from the tool is either on the command-line, or to a reporting service URL.

With this line added, the local database is now updated and can be monitored instead of having to look at the Storage Service database. 

Connected to archivematica/issues#318 

Question for @jraddaoui or @ablwr should this change result in the version number being bumped, or should it be done once we've grouped a few issues and crafted a release? (I don't think we've been using [releases](https://github.com/artefactual/fixity/releases) here the same way as other projects like [mets-reader-writer](https://github.com/artefactual-labs/mets-reader-writer/releases))