### PR TITLE
Refresh Fixity Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,246 @@
 fixity
 ======
 
-Fixity is a simple commandline tool that assists in checking fixity for AIPs stored in Archivematica Storage Service instances.
+Fixity is a command line tool that assists in checking fixity for AIPs stored
+in the Archivematica Storage Service.
 
-The Archivematica Storage Service provides a REST API endpoint for checking fixity of AIPs. This tool provides a simple commandline interface to that functionality, in a way that's simple to automate.
+*"Fixity"* in digital preservation terms is defined as *"the assurance that a
+digital file has remained unchanged, i.e. fixed."*
+[(Bailey, 2014)](https://blogs.loc.gov/thesignal/2014/04/protect-your-data-file-fixity-and-data-integrity/)
+and more information about that, and the concept of checksums, can be found in
+the Digital Preservation Coalition's (DPC)
+[Digital Preservation Handbook](https://www.dpconline.org/handbook/technical-solutions-and-tools/fixity-and-checksums).
 
+Fixity is a client application that calls the Storage Service's
+[Check Fixity](https://wiki.archivematica.org/Storage_Service_API#Check_fixity)
+API endpoint for a single AIP or for each AIP in the Storage Service.
 
+Check Fixity
+------------
+
+The Storage Service's Check Fixity endpoint can be used to trigger a fixity
+check on an individual package. When the Fixity client calls this endpoint, the
+checking is done in the Storage Service itself.
+
+Fixity aggregates results and makes it easy to do this across all packages.
+
+To trigger fixity checking for a package, we need to know the AIP UUID and the
+Storage Service authorization parameters.
+
+The URL is constructed as follows:
+`http://127.0.0.1:62081/api/v2/file/<AIP UUID>/check_fixity/`
+
+And we can supply authentication information in a HTTP request using a command
+line tool such as [HTTPie](https://httpie.org):
+```bash
+http -v --pretty=format \
+    GET "http://127.0.0.1:62081/api/v2/file/5e21dd0d-190e-4ffb-b752-76d860bea898/check_fixity/" \
+    Authorization:"ApiKey test:test"
+```
+
+This results in the following JSON output showing us that the Fixity check was
+a 'success', that is, there were no errors:
+```json
+{
+    "failures": {
+        "files": {
+            "changed": [],
+            "missing": [],
+            "untracked": []
+        }
+    },
+    "message": "",
+    "success": true,
+    "timestamp": null
+}
+```
+
+This detailed JSON output is recorded in Fixity's internal database. Summary
+information about errors is printed to the console. The output for package
+`5e21dd0d-190e-4ffb-b752-76d860bea898` would simply look as follows:
+
+`Fixity scan succeeded for AIP: 5e21dd0d-190e-4ffb-b752-76d860bea898`
+
+The Check Fixity endpoint updates the Storage Service `fixitylog` model with
+details of the last check completed.
+
+Storage Service users can see the last `Fixity Date` and `Fixity Status` in the
+Storage Service Packages panel by going to `{storage-service-url}/packages/`
+
+Administrators of the Storage Service can query the Storage Service database as
+follows:
+```sql
+select
+   package_id as "AIP UUID",
+   datetime_reported as "Fixity Last Checked",
+   success,
+   error_details
+from locations_fixitylog
+where package_id = '5e21dd0d-190e-4ffb-b752-76d860bea898'
+order by datetime_reported desc
+limit 1;
+```
+
+And we can see the details of the check in the SQL output:
+```sql
++--------------------------------------+----------------------------+---------+---------------+
+| AIP UUID                             | Fixity Last Checked        | success | error_details |
++--------------------------------------+----------------------------+---------+---------------+
+| 5e21dd0d-190e-4ffb-b752-76d860bea898 | 2018-11-06 11:20:43.634188 |       1 | NULL          |
++--------------------------------------+----------------------------+---------+---------------+
+```
+
+Fixity Errors
+-------------
+
+The Storage Service can detect multiple categories of error. Some are shown as
+outputs of Fixity below with the corresponding detailed information that can
+be accessed from Fixity's database:
+
+### Information has been deleted from a file
+```
+Fixity scan failed for AIP: 5e21dd0d-190e-4ffb-b752-76d860bea898 (Oxum error.
+Found 10 files and 126404 bytes on disk; expected 10 files and 126405 bytes.)
+```
+
+**Detail:**
+```json
+{
+    "failures": {
+        "files": {
+            "changed": [],
+            "missing": [],
+            "untracked": []
+        }
+    },
+    "finished": 1541505247,
+    "message": "Oxum error.  Found 10 files and 126404 bytes on disk; expected 10 files and 126405 bytes.",
+    "started": 1541505247,
+    "success": false,
+    "timestamp": null
+}
+```
+
+### A character in a file has been modified
+```
+Fixity scan failed for AIP: 5e21dd0d-190e-4ffb-b752-76d860bea898 (invalid bag)
+```
+
+**Detail:**
+```json
+{
+    "failures": {
+        "files": {
+            "changed": [
+                {
+                    "actual": "6ea7859a4edb8406aae0dfdf5abda9db97eeb8b416922b7356082ab55c9e4161",
+                    "expected": "9fd57a8c09e0443de485cf51b68ad8ef54486454434daed499d2f686b7efc2b4",
+                    "hash_type": "sha256",
+                    "message": "data/objects/one_file/one_file.txt checksum validation failed (alg=sha256 expected=9fd57a8c09e0443de485cf51b68ad8ef54486454434daed499d2f686b7efc2b4 found=6ea7859a4edb8406aae0dfdf5abda9db97eeb8b416922b7356082ab55c9e4161)",
+                    "path": "data/objects/one_file/one_file.txt"
+                }
+            ],
+            "missing": [],
+            "untracked": []
+        }
+    },
+    "finished": 1541505387,
+    "message": "invalid bag",
+    "started": 1541505386,
+    "success": false,
+    "timestamp": null
+}
+```
+
+### A file has been removed from the package
+```
+Fixity scan failed for AIP: 5e21dd0d-190e-4ffb-b752-76d860bea898 (Oxum error.
+Found 9 files and 126386 bytes on disk; expected 10 files and 126405 bytes.)
+```
+
+**Detail:**
+```json
+{
+    "failures": {
+        "files": {
+            "changed": [],
+            "missing": [],
+            "untracked": []
+        }
+    },
+    "finished": 1541505645,
+    "message": "Oxum error.  Found 9 files and 126386 bytes on disk; expected 10 files and 126405 bytes.",
+    "started": 1541505645,
+    "success": false,
+    "timestamp": null
+}
+```
+
+### A file has been added to the package
+```
+Fixity scan failed for AIP: 5e21dd0d-190e-4ffb-b752-76d860bea898 (Oxum error.
+Found 11 files and 126405 bytes on disk; expected 10 files and 126405 bytes.)
+```
+
+**Detail:**
+```json
+{
+    "failures": {
+        "files": {
+            "changed": [],
+            "missing": [],
+            "untracked": []
+        }
+    },
+    "finished": 1541505549,
+    "message": "Oxum error.  Found 11 files and 126405 bytes on disk; expected 10 files and 126405 bytes.",
+    "started": 1541505549,
+    "success": false,
+    "timestamp": null
+}
+
+```
+
+### A manifest has been removed from the package
+```
+Fixity scan failed for AIP: 5e21dd0d-190e-4ffb-b752-76d860bea898 (Missing
+manifest file)
+```
+
+**Detail:**
+```json
+{
+    "failures": {
+        "files": {
+            "changed": [],
+            "missing": [],
+            "untracked": []
+        }
+    },
+    "finished": 1541505815,
+    "message": "Missing manifest file",
+    "started": 1541505815,
+    "success": false,
+    "timestamp": null
+}
+```
+
+### How this looks in the Storage Service
+
+For any error in the Fixity check the Storage Service database maintains a
+summary log, see for example when data in a file has been modified:
+```sql
++--------------------------------------+----------------------------+---------+---------------+
+| AIP UUID                             | Fixity Last Checked        | success | error_details |
++--------------------------------------+----------------------------+---------+---------------+
+| 5e21dd0d-190e-4ffb-b752-76d860bea898 | 2018-11-06 12:10:22.981609 |       0 | invalid bag   |
++--------------------------------------+----------------------------+---------+---------------+
+```
 
 Installation
 ------------
+
+Installation of Fixity can be completed with the following steps:
 
 1. Checkout or link the code to `/usr/lib/archivematica/fixity`
    1. Go to `/usr/lib/archivematica/`
@@ -21,12 +253,14 @@ Installation
       user@root:/usr/lib/archivematica/$ git clone https://github.com/artefactual/fixity.git
       ```
 
-      Once this is complete, the directory `/usr/lib/archivematica/fixity` should exist. `cd` back to the home directory
+      Once this is complete, the directory `/usr/lib/archivematica/fixity`
+      should exist. `cd` back to the home directory
       ```bash
       user@root:/usr/lib/archivematica/$ cd
       ```
 
-2. Create a virtualenv in `/usr/share/python/fixity`, and install fixity and dependencies in it
+2. Create a virtualenv in `/usr/share/python/fixity`, and install fixity and
+   dependencies in it
 
    1. Switch to root
       ```bash
@@ -42,13 +276,14 @@ Installation
       (fixity)root@host:/usr/lib/archivematica/fixity# python setup.py install
       ```
 
-3. Create a symlink from the executable to /usr/local/bin.  You must still be root.
-
+3. Create a symlink from the executable to `/usr/local/bin`.  You must still be
+   root.
    ```bash
    (fixity)root@host:/usr/lib/archivematica/fixity# ln -s /usr/share/python/fixity/bin/fixity /usr/local/bin/fixity
    ```
 
-4. Export required environment variables. For ease of use later, creating `/etc/profile.d/fixity.sh` is recommended:
+4. Export required environment variables. For ease of use later, creating
+   `/etc/profile.d/fixity.sh` is recommended:
 
    1. To create the file:
       ```bash
@@ -56,7 +291,9 @@ Installation
       (fixity)root@host:/usr/lib/archivematica/fixity# nano /etc/profile.d/fixity.sh
       ```
 
-   2. You are now editing the environment variables file. You should use the URL of your Storage Service, and the username and API key of one Storage Service user. Replace the URL, user and key with your data.
+   2. You are now editing the environment variables file. You should use the
+      URL of your Storage Service, and the username and API key of one Storage
+      Service user. Replace the URL, user and key with your data.
       ```bash
       #!/bin/bash
       export STORAGE_SERVICE_URL=http://localhost:8000
@@ -64,7 +301,8 @@ Installation
       export STORAGE_SERVICE_KEY=myapikey
       ```
 
-   3. Optionally, if you are using Fixity with a reporting service, you can also add:
+   3. Optionally, if you are using Fixity with a reporting service, you can
+      also add:
       ```bash
       export REPORT_URL=http://myurl.com
       export REPORT_USERNAME=myuser
@@ -76,8 +314,8 @@ Installation
       (fixity)root@host:/usr/lib/archivematica/fixity# source /etc/profile.d/fixity.sh
       ```
 
-5. Run the tool with sudo or as root the first time.  Subsequent runs can be with any user.
-
+5. Run the tool with sudo or as root the first time.  Subsequent runs can be
+   with any user.
    ```bash
    (fixity)root@host:/usr/lib/archivematica/fixity# fixity scanall
    ```
@@ -94,7 +332,8 @@ Installation
    user@host:~$
    ```
 
-7. After the initial install, to run fixity you only need to load the variables you defined earlier and run fixity.
+7. After the initial install, to run fixity you only need to load the variables
+   you defined earlier and run fixity.
    ```bash
    user@host:~$ source /etc/profile.d/fixity.sh
    user@host:~$ fixity scanall
@@ -108,4 +347,4 @@ For more information on usage, consult the [manpage](docs/fixity.1.md).
 Copyright
 ---------
 
-Fixity is copyright 2014,2015,2016 Artefactual Systems Inc.
+Fixity is copyright 2014-2018 Artefactual Systems Inc.

--- a/docs/fixity.1
+++ b/docs/fixity.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FIXITY" "1" "May 2016" "" ""
+.TH "FIXITY" "1" "November 2018" "" ""
 .
 .SH "NAME"
 \fBfixity\fR \- Check fixity for AIPs
@@ -10,7 +10,10 @@
 \fBfixity\fR command [options] [UUID]
 .
 .SH "DESCRIPTION"
-fixity is a tool to check fixity of Archival Information Packages (AIPs) stored using the Archivematica Storage Service\.
+fixity is a command line tool that assists in checking fixity for AIPs stored in the Archivematica Storage Service\.
+.
+.P
+fixity is a client application that calls the Storage Service\'s Check Fixity API endpoint for a single AIP or for each AIP in the Storage Service\. The Storage Service performs the fixity check itself and the results are reported on by the fixity client application\.
 .
 .P
 fixity can be configured to POST its reports to a remote service after completing every scan\. It also retains an internal database which keeps track of every AIP it\'s scanned and a report of every scan\.
@@ -22,11 +25,11 @@ fixity requires several environment variables to be exported when it is running;
 .
 .TP
 \fB\-\-throttle\fR \fIseconds\fR
-Time (in seconds) to wait when scanning multiple AIPs\. This can help reduce extended disk load on the filesystem on which the AIPs reside\.
+Time (in seconds) to wait when scanning multiple AIPs\. This can help reduce extended disk load on the Storage Service filesystem on which the AIPs reside\.
 .
 .TP
 \fB\-\-force\-local\fR
-Request the Storage Service performs a local fixity check, instead of using the Space\'s fixity (if available)\.
+Request the Storage Service performs a local fixity check, instead of using the Space\'s fixity (this is only available for Arkivum Spaces)\.
 .
 .TP
 \fB\-\-debug\fR

--- a/docs/fixity.1.html
+++ b/docs/fixity.1.html
@@ -78,17 +78,29 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>fixity is a tool to check fixity of Archival Information Packages (AIPs) stored using the Archivematica Storage Service.</p>
+<p>fixity is a command line tool that assists in checking fixity for AIPs stored
+in the Archivematica Storage Service.</p>
 
-<p>fixity can be configured to POST its reports to a remote service after completing every scan. It also retains an internal database which keeps track of every AIP it's scanned and a report of every scan.</p>
+<p>fixity is a client application that calls the Storage Service's Check Fixity
+API endpoint for a single AIP or for each AIP in the Storage Service. The
+Storage Service performs the fixity check itself and the results are reported
+on by the fixity client application.</p>
 
-<p>fixity requires several environment variables to be exported when it is running; see the section on <em>ENVIRONMENT VARIABLES</em> for information.</p>
+<p>fixity can be configured to POST its reports to a remote service after
+completing every scan. It also retains an internal database which keeps track
+of every AIP it's scanned and a report of every scan.</p>
+
+<p>fixity requires several environment variables to be exported when it is
+running; see the section on <em>ENVIRONMENT VARIABLES</em> for information.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <dl>
-<dt><code>--throttle</code> <var>seconds</var></dt><dd><p>Time (in seconds) to wait when scanning multiple AIPs. This can help reduce extended disk load on the filesystem on which the AIPs reside.</p></dd>
-<dt><code>--force-local</code></dt><dd><p>Request the Storage Service performs a local fixity check, instead of using the Space's fixity (if available).</p></dd>
+<dt><code>--throttle</code> <var>seconds</var></dt><dd><p>Time (in seconds) to wait when scanning multiple AIPs. This can help reduce
+extended disk load on the Storage Service filesystem on which the AIPs
+reside.</p></dd>
+<dt><code>--force-local</code></dt><dd><p>Request the Storage Service performs a local fixity check, instead of using
+the Space's fixity (this is only available for Arkivum Spaces).</p></dd>
 <dt class="flush"><code>--debug</code></dt><dd><p>Print extra debugging output.</p></dd>
 </dl>
 
@@ -96,26 +108,37 @@
 <h2 id="COMMANDS">COMMANDS</h2>
 
 <dl>
-<dt><code>scan</code> <var>UUID</var></dt><dd><p>Run a fixity scan on a single AIP, using the specified UUID. If the UUID is malformed, or the Storage Service does not have an AIP with the specified UUID, this will produce an error and exit 1. After the scan completes, a brief report will be printed with information on whether the scan succeeded or failed.</p></dd>
-<dt class="flush"><code>scanall</code></dt><dd><p>Run a fixity scan on every AIP registered with the target Storage Service instance. This command does not take any arguments. A brief report will be printed after every AIP is scanned.</p>
+<dt><code>scan</code> <var>UUID</var></dt><dd><p>Run a fixity scan on a single AIP, using the specified UUID. If the UUID is
+malformed, or the Storage Service does not have an AIP with the specified
+UUID, this will produce an error and exit 1. After the scan completes, a
+brief report will be printed with information on whether the scan succeeded
+or failed.</p></dd>
+<dt class="flush"><code>scanall</code></dt><dd><p>Run a fixity scan on every AIP registered with the target Storage Service
+instance. This command does not take any arguments. A brief report will be
+printed after every AIP is scanned.</p>
 
-<p>If <code>--throttle</code> is passed, then the tool will pause for the specified number of seconds between scans.</p></dd>
+<p>If <code>--throttle</code> is passed, then the tool will pause for the specified
+number of seconds between scans.</p></dd>
 </dl>
 
 
 <h2 id="ENVIRONMENT-VARIABLES">ENVIRONMENT VARIABLES</h2>
 
-<p>The following environment variables <strong>must</strong> be exported in the environment for fixity to operate.</p>
+<p>The following environment variables <strong>must</strong> be exported in the environment for
+fixity to operate.</p>
 
 <dl>
-<dt><strong>STORAGE_SERVICE_URL</strong></dt><dd><p>The base URL to the storage service instance to scan. Must include the port number for non port 80 installations. Example:
+<dt><strong>STORAGE_SERVICE_URL</strong></dt><dd><p>The base URL to the storage service instance to scan. Must include the port
+number for non port 80 installations. Example:
   http://localhost:8000/</p></dd>
 <dt><strong>STORAGE_SERVICE_USER</strong></dt><dd><p>Username for API authentication with the storage service. Example:
   test</p></dd>
 <dt><strong>STORAGE_SERVICE_KEY</strong></dt><dd><p>API key for API authentication with the storage service. Example:
   dfe83300db5f05f63157f772820bb028bd4d0e27</p></dd>
 <dt><strong>REPORT_URL</strong></dt><dd><p>The base URL to the remote service to which scan reports will be POSTed.</p></dd>
-<dt><strong>REPORT_USERNAME</strong></dt><dd><p>Username for API authentication with the reporting service. Not all reporting services require API authentication; leave this unset if API access is unauthenticated.</p></dd>
+<dt><strong>REPORT_USERNAME</strong></dt><dd><p>Username for API authentication with the reporting service. Not all
+reporting services require API authentication; leave this unset if API
+access is unauthenticated.</p></dd>
 <dt><strong>REPORT_PASSWORD</strong></dt><dd><p>Password for API authentication with the reporting service; see above.</p></dd>
 </dl>
 
@@ -123,7 +146,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>May 2016</li>
+    <li class='tc'>November 2018</li>
     <li class='tr'>fixity(1)</li>
   </ol>
 

--- a/docs/fixity.1.md
+++ b/docs/fixity.1.md
@@ -7,19 +7,31 @@ fixity(1) -- Check fixity for AIPs
 
 ## DESCRIPTION
 
-fixity is a tool to check fixity of Archival Information Packages (AIPs) stored using the Archivematica Storage Service.
+fixity is a command line tool that assists in checking fixity for AIPs stored
+in the Archivematica Storage Service.
 
-fixity can be configured to POST its reports to a remote service after completing every scan. It also retains an internal database which keeps track of every AIP it's scanned and a report of every scan.
+fixity is a client application that calls the Storage Service's Check Fixity
+API endpoint for a single AIP or for each AIP in the Storage Service. The
+Storage Service performs the fixity check itself and the results are reported
+on by the fixity client application.
 
-fixity requires several environment variables to be exported when it is running; see the section on _ENVIRONMENT VARIABLES_ for information.
+fixity can be configured to POST its reports to a remote service after
+completing every scan. It also retains an internal database which keeps track
+of every AIP it's scanned and a report of every scan.
+
+fixity requires several environment variables to be exported when it is
+running; see the section on _ENVIRONMENT VARIABLES_ for information.
 
 ## OPTIONS
 
   * `--throttle` <seconds>:
-    Time (in seconds) to wait when scanning multiple AIPs. This can help reduce extended disk load on the filesystem on which the AIPs reside.
+    Time (in seconds) to wait when scanning multiple AIPs. This can help reduce
+    extended disk load on the Storage Service filesystem on which the AIPs
+    reside.
 
   * `--force-local`:
-    Request the Storage Service performs a local fixity check, instead of using the Space's fixity (if available).
+    Request the Storage Service performs a local fixity check, instead of using
+    the Space's fixity (this is only available for Arkivum Spaces).
 
   * `--debug`:
     Print extra debugging output.
@@ -27,19 +39,28 @@ fixity requires several environment variables to be exported when it is running;
 ## COMMANDS
 
   * `scan` <UUID>:
-    Run a fixity scan on a single AIP, using the specified UUID. If the UUID is malformed, or the Storage Service does not have an AIP with the specified UUID, this will produce an error and exit 1. After the scan completes, a brief report will be printed with information on whether the scan succeeded or failed.
+    Run a fixity scan on a single AIP, using the specified UUID. If the UUID is
+    malformed, or the Storage Service does not have an AIP with the specified
+    UUID, this will produce an error and exit 1. After the scan completes, a
+    brief report will be printed with information on whether the scan succeeded
+    or failed.
 
   * `scanall`:
-    Run a fixity scan on every AIP registered with the target Storage Service instance. This command does not take any arguments. A brief report will be printed after every AIP is scanned.
+    Run a fixity scan on every AIP registered with the target Storage Service
+    instance. This command does not take any arguments. A brief report will be
+    printed after every AIP is scanned.
 
-    If `--throttle` is passed, then the tool will pause for the specified number of seconds between scans.
+    If `--throttle` is passed, then the tool will pause for the specified
+    number of seconds between scans.
 
 ## ENVIRONMENT VARIABLES
 
-The following environment variables **must** be exported in the environment for fixity to operate.
+The following environment variables **must** be exported in the environment for
+fixity to operate.
 
   * **STORAGE_SERVICE_URL**:
-    The base URL to the storage service instance to scan. Must include the port number for non port 80 installations. Example:
+    The base URL to the storage service instance to scan. Must include the port
+    number for non port 80 installations. Example:
       http://localhost:8000/
 
   * **STORAGE_SERVICE_USER**:
@@ -54,7 +75,9 @@ The following environment variables **must** be exported in the environment for 
     The base URL to the remote service to which scan reports will be POSTed.
 
   * **REPORT_USERNAME**:
-    Username for API authentication with the reporting service. Not all reporting services require API authentication; leave this unset if API access is unauthenticated.
+    Username for API authentication with the reporting service. Not all
+    reporting services require API authentication; leave this unset if API
+    access is unauthenticated.
 
   * **REPORT_PASSWORD**:
     Password for API authentication with the reporting service; see above.


### PR DESCRIPTION
This PR refreshes the Fixity documentation.

For reviewers, you'll see 8 commits which I've tried to group as logically as possible for review. I propose to squish them all into a single commit before merging. 

Of the four files modified, two are generated automatically using https://github.com/rtomayko/ronn from [fixity.1.md](https://github.com/artefactual/fixity/blob/dev/issue-317-refresh-fixity-docs/docs/fixity.1.md)

The two that have been updated for their content, aside from their diffs, are best viewed in a GitHub markdown viewer:

* README.md: https://github.com/artefactual/fixity/blob/dev/issue-317-refresh-fixity-docs/README.md
* Manual Page: https://github.com/artefactual/fixity/blob/dev/issue-317-refresh-fixity-docs/docs/fixity.1.md

Connected to archivematica/issues#317