### PR TITLE
Fix issues identified in Python 3 migration project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
     - python: "2.7"
       env: TOXENV=py27
 
+    - python: "3.5"
+      env: TOXENV=py35
+
     - python: "3.6"
       env: TOXENV=py36
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,13 @@ matrix:
   fast_finish: true
   include:
 
+    - python: "2.7"
+      env: TOXENV=py27
+
+    - python: "3.6"
+      env: TOXENV=py36
+
+    # Linters
+
     - python: "3.7"
       env: TOXENV=linting

--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -108,7 +108,7 @@ def get_single_aip(uuid, ss_url, ss_user, ss_key):
     try:
         response = requests.get(ss_url + "api/v2/file/" + uuid + "/", params=params)
     except requests.ConnectionError:
-        raise (StorageServiceError(UNABLE_TO_CONNECT_ERROR.format(ss_url)))
+        raise StorageServiceError(UNABLE_TO_CONNECT_ERROR.format(ss_url))
 
     if response.status_code == 500:
         raise StorageServiceError(

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,4 +1,4 @@
 -r base.txt
 ipython==2.0.0
-pytest==5.1.1
+pytest==4.6.5
 vcrpy==1.0.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,4 +1,4 @@
 -r base.txt
 ipython==2.0.0
-pytest==2.8.7
+pytest==5.1.1
 vcrpy==1.0.0

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -255,7 +255,7 @@ def test_fixity_scan_raises_on_invalid_url():
     error_msgs = (
         "Unable to connect",
         "fixity scan could not be started",
-        "returned 410"
+        "returned 410",
     )
     assert any(msg in str(ex.value) for msg in error_msgs)
 

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -158,7 +158,8 @@ def test_get_all_aips_raises_with_invalid_url():
             "http://foo", STORAGE_SERVICE_USER, STORAGE_SERVICE_KEY
         )
 
-    assert "Unable to connect" in str(ex.value)
+    error_msgs = ("Unable to connect", "returned 404", "returned 410")
+    assert any(msg in str(ex.value) for msg in error_msgs)
 
 
 @vcr.use_cassette("fixtures/vcr_cassettes/all_aips_bad_auth.yaml")

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -85,7 +85,8 @@ def test_single_aip_raises_with_invalid_url():
             STORAGE_SERVICE_KEY,
         )
 
-    assert "Unable to connect" in str(ex.value)
+    error_msgs = ("Unable to connect", "returned 404", "returned 410")
+    assert any(msg in str(ex.value) for msg in error_msgs)
 
 
 @vcr.use_cassette("fixtures/vcr_cassettes/single_aip_bad_auth.yaml")
@@ -251,7 +252,12 @@ def test_fixity_scan_raises_on_invalid_url():
             SESSION,
         )
 
-    assert "Unable to connect" in str(ex.value)
+    error_msgs = (
+        "Unable to connect",
+        "fixity scan could not be started",
+        "returned 410"
+    )
+    assert any(msg in str(ex.value) for msg in error_msgs)
 
 
 @vcr.use_cassette("fixtures/vcr_cassettes/fixity_bad_auth.yaml")

--- a/tox.ini
+++ b/tox.ini
@@ -2,19 +2,10 @@
 skipsdist = True
 envlist = py27,py36,linting
 
-[testenv:py27]
-basepython = python2
+[testenv]
 skip_install = True
 deps = -rrequirements/local.txt
-whitelist_externals = pytest
-commands = pytest {posargs}
-
-[testenv:py36]
-basepython = python3
-skip_install = True
-deps = -rrequirements/local.txt
-whitelist_externals = pytest
-commands = pytest {posargs}
+commands = py.test
 
 [testenv:linting]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py27,py35,py36,linting
 [testenv]
 skip_install = True
 deps = -rrequirements/local.txt
+whitelist_externals = pytest
 commands = pytest
 
 [testenv:linting]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py36,linting
+envlist = py27,py35,py36,linting
 
 [testenv]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 skipsdist = True
-minversion = 2.7.0
-envlist = linting
+envlist = py27,py36,linting
 
 [testenv]
+deps = -rrequirements/local.txt
 skip_install = True
+commands = pytest {posargs}
 
 [testenv:linting]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,py35,py36,linting
 [testenv]
 skip_install = True
 deps = -rrequirements/local.txt
-commands = py.test
+commands = pytest
 
 [testenv:linting]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,py36,linting
 [testenv]
 deps =
 	-rrequirements/local.txt
-	-rrequirements/production.txt
+	-rrequirements/base.txt
 skip_install = True
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ skipsdist = True
 envlist = py27,py36,linting
 
 [testenv]
-deps = -rrequirements/local.txt
+deps =
+	-rrequirements/local.txt
+	-rrequirements/production.txt
 skip_install = True
 commands = pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,18 @@
 skipsdist = True
 envlist = py27,py36,linting
 
-[testenv]
-deps =
-	-rrequirements/local.txt
-	-rrequirements/base.txt
+[testenv:py27]
+basepython = python2
 skip_install = True
+deps = -rrequirements/local.txt
+whitelist_externals = pytest
+commands = pytest {posargs}
+
+[testenv:py36]
+basepython = python3
+skip_install = True
+deps = -rrequirements/local.txt
+whitelist_externals = pytest
 commands = pytest {posargs}
 
 [testenv:linting]


### PR DESCRIPTION
Hi all,

This PR is related to https://github.com/archivematica/Issues/issues/814 and the Python 3 project, and introduces two small changes to the Fixity application:

* Removes unnecessary parentheses in a raise statement, which were identified as a syntactic error by `2to3`
* Modifies the `.travis.yml` and `tox.ini` configuration files so that the existing tests will be run in TravisCI moving forward