### PR TITLE
Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 18.9b0
+  rev: 22.8.0
   hooks:
   - id: black
     args: [--safe, --quiet]
     language_version: python3
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.7
+- repo: https://github.com/pycqa/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
     language_version: python3

--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -69,7 +69,7 @@ def _get_aips(ss_url, ss_user, ss_key, uri=None):
     filtered_aips = [
         aip
         for aip in results["objects"]
-        if aip["package_type"] == "AIP" and aip["status"] == u"UPLOADED"
+        if aip["package_type"] == "AIP" and aip["status"] == "UPLOADED"
     ]
     results["objects"] = filtered_aips
     return results

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -126,7 +126,7 @@ def test_get_all_aips_gets_uploaded_aips_only():
     aips = storage_service.get_all_aips(
         STORAGE_SERVICE_URL, STORAGE_SERVICE_USER, STORAGE_SERVICE_KEY
     )
-    non_uploaded = list(filter(lambda a: a["status"] != u"UPLOADED", aips))
+    non_uploaded = list(filter(lambda a: a["status"] != "UPLOADED", aips))
     assert len(non_uploaded) == 0
 
 


### PR DESCRIPTION
This updates the versions of the pre-commit dependencies to support Python 3.6 and fixes the URL of the flake8 repository.

Connected to https://github.com/archivematica/Issues/issues/1558