### PR TITLE
Add utility function to calculate current time

### DIFF
--- a/fixity/fixity.py
+++ b/fixity/fixity.py
@@ -3,12 +3,12 @@ import os
 import sys
 import traceback
 from argparse import ArgumentParser
-from datetime import datetime
 from time import sleep
 from uuid import uuid4
 
 from . import reporting
 from . import storage_service
+from . import utils
 from .models import Report
 from .models import Session
 
@@ -123,7 +123,7 @@ def scan(
     # while attempting to respond to the request.
     storage_service.get_single_aip(aip, ss_url, ss_user, ss_key)
 
-    start_time = datetime.utcnow()
+    start_time = utils.utcnow()
 
     try:
         if report_url:

--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -190,7 +190,7 @@ def scan_aip(
             aip = AIP(uuid=aip_uuid)
 
     if not start_time:
-        begun = datetime.utcnow()
+        begun = utils.utcnow()
     else:
         begun = start_time
 
@@ -203,7 +203,7 @@ def scan_aip(
         )
     except requests.ConnectionError:
         raise StorageServiceError(UNABLE_TO_CONNECT_ERROR.format(ss_url))
-    ended = datetime.utcnow()
+    ended = utils.utcnow()
 
     begun_int = int(calendar.timegm(begun.utctimetuple()))
     ended_int = int(calendar.timegm(ended.utctimetuple()))

--- a/fixity/storage_service.py
+++ b/fixity/storage_service.py
@@ -5,9 +5,9 @@ from datetime import datetime
 import requests
 from sqlalchemy.orm.exc import NoResultFound
 
+from . import utils
 from .models import AIP
 from .models import Report
-from .utils import check_valid_uuid
 
 
 UNABLE_TO_CONNECT_ERROR = (
@@ -103,7 +103,7 @@ def get_single_aip(uuid, ss_url, ss_user, ss_key):
     Given an AIP UUID, fetches a dict with full information on the AIP
     from the storage service.
     """
-    check_valid_uuid(uuid)
+    utils.check_valid_uuid(uuid)
 
     params = {"username": ss_user, "api_key": ss_key}
     try:
@@ -182,7 +182,7 @@ def scan_aip(
     if isinstance(aip_uuid, AIP):
         aip = aip_uuid
     else:
-        check_valid_uuid(aip_uuid)
+        utils.check_valid_uuid(aip_uuid)
 
         try:
             aip = session.query(AIP).filter_by(uuid=aip_uuid).one()

--- a/fixity/utils.py
+++ b/fixity/utils.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from datetime import timezone
 from uuid import UUID
 
 
@@ -27,3 +29,7 @@ def check_valid_uuid(uuid):
         raise InvalidUUID(uuid)
 
     return True
+
+
+def utcnow():
+    return datetime.now(timezone.utc)

--- a/tests/test_fixity.py
+++ b/tests/test_fixity.py
@@ -74,27 +74,8 @@ def test_scan(_get, mock_check_fixity):
     ]
 
 
-def setup_dt_mock(mock, t):
-    d = datetime.fromtimestamp(t, timezone.utc)
-    mock.utcnow.return_value = d
-    mock.side_effect = lambda *args, **kw: datetime(*args, **kw)
-
-
-@pytest.fixture
-def start_time():
-    result = 1514775600
-    with mock.patch("fixity.fixity.datetime") as fixity_datetime, mock.patch(
-        "fixity.storage_service.datetime"
-    ) as storage_service_datetime:
-        setup_dt_mock(fixity_datetime, result)
-        setup_dt_mock(storage_service_datetime, result)
-
-        yield result
-
-
-@mock.patch(
-    "requests.get",
-)
+@mock.patch("fixity.utils.utcnow")
+@mock.patch("requests.get")
 @mock.patch(
     "requests.post",
     side_effect=[
@@ -102,8 +83,10 @@ def start_time():
         mock.Mock(status_code=201, spec=requests.Response),
     ],
 )
-def test_scan_if_report_url_exists(_post, _get, mock_check_fixity, start_time):
+def test_scan_if_report_url_exists(_post, _get, utcnow, mock_check_fixity):
     _get.side_effect = mock_check_fixity
+    start_time = 1514775600
+    utcnow.return_value = datetime.fromtimestamp(start_time, timezone.utc)
     aip_id = uuid.uuid4()
 
     response = fixity.scan(


### PR DESCRIPTION
This is a follow up on https://github.com/artefactual/fixity/pull/41 to centralize the `datetime.utcnow` calls from the `fixity` and `storage_service` modules into a single utility function.