### PR TITLE
Create argument to display timestamps

### DIFF
--- a/docs/fixity.1
+++ b/docs/fixity.1
@@ -35,6 +35,10 @@ Request the Storage Service performs a local fixity check, instead of using the 
 \fB\-\-debug\fR
 Print extra debugging output\.
 .
+.TP
+\fB\-\-timestamps\fR
+Add a timestamp to the beginning of each line of output.\.
+.
 .SH "COMMANDS"
 .
 .TP

--- a/docs/fixity.1
+++ b/docs/fixity.1
@@ -37,7 +37,7 @@ Print extra debugging output\.
 .
 .TP
 \fB\-\-timestamps\fR
-Add a timestamp to the beginning of each line of output.\.
+Add a timestamp to the beginning of each line of output\.
 .
 .SH "COMMANDS"
 .

--- a/docs/fixity.1.html
+++ b/docs/fixity.1.html
@@ -101,6 +101,7 @@ extended disk load on the Storage Service filesystem on which the AIPs
 reside.</p></dd>
 <dt><code>--force-local</code></dt><dd><p>Request the Storage Service performs a local fixity check, instead of using
 the Space's fixity (this is only available for Arkivum Spaces).</p></dd>
+<dt><code>--timestamps</code></dt><dd><p>Add a timestamp to the beginning of each line of output.</p></dd>
 <dt class="flush"><code>--debug</code></dt><dd><p>Print extra debugging output.</p></dd>
 </dl>
 

--- a/docs/fixity.1.md
+++ b/docs/fixity.1.md
@@ -36,7 +36,7 @@ running; see the section on _ENVIRONMENT VARIABLES_ for information.
     Print extra debugging output.
 
 * `--timestamps`:
-  It adds a timestamp to the beginning of each line of output.
+    It adds a timestamp to the beginning of each line of output.
 
 ## COMMANDS
 

--- a/docs/fixity.1.md
+++ b/docs/fixity.1.md
@@ -35,6 +35,9 @@ running; see the section on _ENVIRONMENT VARIABLES_ for information.
 * `--debug`:
     Print extra debugging output.
 
+* `--timestamps`:
+  It adds a timestamp to the beginning of each line of output.
+
 ## COMMANDS
 
 * `scan <UUID>`:

--- a/fixity/fixity.py
+++ b/fixity/fixity.py
@@ -40,6 +40,11 @@ def parse_arguments():
         action="store_true",
         help="Force a local fixity check on the Storage Service.",
     )
+    parser.add_argument(
+        "--timestamp",
+        action="store_true",
+        help="Display the timestamp of the AIP fixity scan.",
+    )
     args = parser.parse_args()
 
     validate_arguments(args)
@@ -99,6 +104,7 @@ def scan(
     report_auth=(),
     session_id=None,
     force_local=False,
+    timestamp=False,
 ):
     """
     Instruct the storage service to scan a single AIP.
@@ -135,7 +141,9 @@ def scan(
                 session_id=session_id,
             )
     except reporting.ReportServiceException:
-        utils.pyprint(f"Unable to POST pre-scan report to {report_url}")
+        utils.pyprint(
+            f"Unable to POST pre-scan report to {report_url}", display_time=timestamp
+        )
 
     try:
         status, report = storage_service.scan_aip(
@@ -148,9 +156,11 @@ def scan(
             force_local=force_local,
         )
         report_data = json.loads(report.report)
-        utils.pyprint(scan_message(aip, status, report_data["message"]))
+        utils.pyprint(
+            scan_message(aip, status, report_data["message"]), display_time=timestamp
+        )
     except Exception as e:
-        utils.pyprint(str(e))
+        utils.pyprint(str(e), display_time=timestamp)
         status = None
         if hasattr(e, "report") and e.report:
             report = e.report
@@ -179,7 +189,10 @@ def scan(
                 aip, report, report_url, report_auth=report_auth, session_id=session_id
             )
         except reporting.ReportServiceException:
-            utils.pyprint(f"Unable to POST report for AIP {aip} to remote service")
+            utils.pyprint(
+                f"Unable to POST report for AIP {aip} to remote service",
+                display_time=timestamp,
+            )
 
     if report:
         session.add(report)
@@ -196,6 +209,7 @@ def scanall(
     report_auth=(),
     throttle_time=0,
     force_local=False,
+    timestamp=False,
 ):
     """
     Run a fixity scan on every AIP in a storage service instance.
@@ -206,7 +220,8 @@ def scanall(
     :param str report_url: The base URL to a server to which the report will be POSTed after the scan completes. If absent, the report will not be transmitted.
     :param report_auth: Authentication for the report_url. Tupel of (user, password) for HTTP auth.
     :param int throttle_time: Time to wait between scans.
-    :param bool force_local: If True, will will request the Storage Service to perform a local fixity check, instead of using the Space's fixity (if available).
+    :param bool force_local: If True, will request the Storage Service to perform a local fixity check, instead of using the Space's fixity (if available).
+    :param bool timestamp: If True, will display the local time stamp of the AIP fixity scan.
     """
     success = True
 
@@ -231,6 +246,7 @@ def scanall(
                 report_auth=report_auth,
                 session_id=session_id,
                 force_local=force_local,
+                timestamp=timestamp,
             )
             if not scan_success:
                 success = False
@@ -238,12 +254,13 @@ def scanall(
             utils.pyprint(
                 f"Internal error encountered while scanning AIP {aip['uuid']} ({type(e).__name__})",
                 file=sys.stdout,
+                display_time=timestamp,
             )
         if throttle_time:
             sleep(throttle_time)
 
     if count > 0:
-        utils.pyprint(f"Successfully scanned {count} AIPs")
+        utils.pyprint(f"Successfully scanned {count} AIPs", display_time=timestamp)
 
     return success
 
@@ -283,6 +300,7 @@ def main():
                 report_auth=auth,
                 throttle_time=args.throttle,
                 force_local=args.force_local,
+                timestamp=args.timestamp,
             )
         elif args.command == "scan":
             session_id = str(uuid4())
@@ -296,6 +314,7 @@ def main():
                 report_auth=auth,
                 session_id=session_id,
                 force_local=args.force_local,
+                timestamp=args.timestamp,
             )
         else:
             return Exception(f'Error: "{args.command}" is not a valid command.')

--- a/fixity/utils.py
+++ b/fixity/utils.py
@@ -41,6 +41,6 @@ def format_timestamp(t):
 
 
 def pyprint(message, **kwargs):
-    if kwargs.get("display_time"):
-        message = f"{[format_timestamp(utcnow())]} " + message
+    if kwargs.get("timestamps"):
+        message = f"{[format_timestamp(utcnow())]} {message}"
     print(message, file=kwargs.get("file", sys.stderr))

--- a/fixity/utils.py
+++ b/fixity/utils.py
@@ -36,5 +36,11 @@ def utcnow():
     return datetime.now(timezone.utc)
 
 
+def format_timestamp(t):
+    return t.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
 def pyprint(message, **kwargs):
+    if kwargs.get("display_time"):
+        message = f"{[format_timestamp(utcnow())]} " + message
     print(message, file=kwargs.get("file", sys.stderr))

--- a/fixity/utils.py
+++ b/fixity/utils.py
@@ -42,5 +42,5 @@ def format_timestamp(t):
 
 def pyprint(message, **kwargs):
     if kwargs.get("timestamps"):
-        message = f"{[format_timestamp(utcnow())]} {message}"
+        message = f"[{format_timestamp(utcnow())}] {message}"
     print(message, file=kwargs.get("file", sys.stderr))

--- a/tests/test_fixity.py
+++ b/tests/test_fixity.py
@@ -10,7 +10,6 @@ import requests
 
 from fixity import fixity
 from fixity import reporting
-from fixity import utils
 from fixity.models import Report
 from fixity.models import Session
 
@@ -75,10 +74,13 @@ def test_scan(_get, mock_check_fixity):
     ]
 
 
+@mock.patch("fixity.utils.utcnow")
 @mock.patch("requests.get")
-def test_scan_if_timestamp_exists(_get, mock_check_fixity, capsys):
+def test_scan_if_timestamps_is_True(_get, utcnow, mock_check_fixity, capsys):
     _get.side_effect = mock_check_fixity
     aip_id = uuid.uuid4()
+    timestamp = 1514775600
+    utcnow.return_value = datetime.fromtimestamp(timestamp, timezone.utc)
 
     response = fixity.scan(
         aip=str(aip_id),
@@ -86,7 +88,7 @@ def test_scan_if_timestamp_exists(_get, mock_check_fixity, capsys):
         ss_user=STORAGE_SERVICE_USER,
         ss_key=STORAGE_SERVICE_KEY,
         session=SESSION,
-        timestamp=True,
+        timestamps=True,
     )
 
     assert response is True
@@ -95,7 +97,7 @@ def test_scan_if_timestamp_exists(_get, mock_check_fixity, capsys):
     assert captured.out == ""
     assert (
         captured.err.strip()
-        == f"['{utils.utcnow().strftime('%Y-%m-%d %H:%M:%S %Z')}'] Fixity scan succeeded for AIP: {aip_id}"
+        == f"['2018-01-01 03:00:00 UTC'] Fixity scan succeeded for AIP: {aip_id}"
     )
     assert _get.mock_calls == [
         mock.call(

--- a/tests/test_fixity.py
+++ b/tests/test_fixity.py
@@ -97,7 +97,7 @@ def test_scan_if_timestamps_is_True(_get, utcnow, mock_check_fixity, capsys):
     assert captured.out == ""
     assert (
         captured.err.strip()
-        == f"['2018-01-01 03:00:00 UTC'] Fixity scan succeeded for AIP: {aip_id}"
+        == f"[2018-01-01 03:00:00 UTC] Fixity scan succeeded for AIP: {aip_id}"
     )
     assert _get.mock_calls == [
         mock.call(

--- a/tests/test_fixity.py
+++ b/tests/test_fixity.py
@@ -76,7 +76,7 @@ def test_scan(_get, mock_check_fixity):
 
 @mock.patch("fixity.utils.utcnow")
 @mock.patch("requests.get")
-def test_scan_if_timestamps_is_True(_get, utcnow, mock_check_fixity, capsys):
+def test_scan_if_timestamps_argument_is_passed(_get, utcnow, mock_check_fixity, capsys):
     _get.side_effect = mock_check_fixity
     aip_id = uuid.uuid4()
     timestamp = 1514775600


### PR DESCRIPTION
The `--timestamps` option will display the date and time of the AIP fixity scan.