### PR TITLE
Direct all print messages to stderr

### DIFF
--- a/fixity/fixity.py
+++ b/fixity/fixity.py
@@ -254,7 +254,6 @@ def scanall(
         except Exception as e:
             utils.pyprint(
                 f"Internal error encountered while scanning AIP {aip['uuid']} ({type(e).__name__})",
-                file=sys.stdout,
                 timestamps=timestamps,
             )
         if throttle_time:

--- a/fixity/utils.py
+++ b/fixity/utils.py
@@ -43,4 +43,4 @@ def format_timestamp(t):
 def pyprint(message, **kwargs):
     if kwargs.get("timestamps"):
         message = f"[{format_timestamp(utcnow())}] {message}"
-    print(message, file=kwargs.get("file", sys.stderr))
+    print(message, file=sys.stderr)

--- a/tests/test_fixity.py
+++ b/tests/test_fixity.py
@@ -421,13 +421,10 @@ def test_scanall_handles_exceptions(_get, capsys):
     assert response is False
 
     captured = capsys.readouterr()
-    assert (
-        captured.out.strip()
-        == "Internal error encountered while scanning AIP 77adb748-8d9c-47ec-b593-53465749ce0e (StorageServiceError)"
-    )
 
     assert captured.err.strip() == "\n".join(
         [
+            "Internal error encountered while scanning AIP 77adb748-8d9c-47ec-b593-53465749ce0e (StorageServiceError)",
             f'Storage service at "{STORAGE_SERVICE_URL}" failed authentication while scanning AIP 32f62f8b-ecfd-419e-a3e9-911ec23d0573',
             "Successfully scanned 2 AIPs",
         ]
@@ -509,12 +506,12 @@ def test_main_handles_exceptions_if_scanall_fails(_get, monkeypatch, capsys):
     assert result == 1
 
     captured = capsys.readouterr()
-    assert (
-        captured.out.strip()
-        == f"Internal error encountered while scanning AIP {aip_id} (StorageServiceError)"
-    )
+
+    assert captured.out.strip() == ""
+
     assert captured.err.strip() == "\n".join(
         [
+            f"Internal error encountered while scanning AIP {aip_id} (StorageServiceError)",
             f'Storage service at "{STORAGE_SERVICE_URL}" failed authentication while scanning AIP 32f62f8b-ecfd-419e-a3e9-911ec23d0573',
             "Successfully scanned 2 AIPs",
         ]

--- a/tests/test_fixity.py
+++ b/tests/test_fixity.py
@@ -506,9 +506,7 @@ def test_main_handles_exceptions_if_scanall_fails(_get, monkeypatch, capsys):
     assert result == 1
 
     captured = capsys.readouterr()
-
     assert captured.out.strip() == ""
-
     assert captured.err.strip() == "\n".join(
         [
             f"Internal error encountered while scanning AIP {aip_id} (StorageServiceError)",


### PR DESCRIPTION
Stream all print messages to stderr so they can be controlled together.